### PR TITLE
Replaced single quotes with double quotes line 29 : az aks list --que…

### DIFF
--- a/docs/2.podidentity.md
+++ b/docs/2.podidentity.md
@@ -26,7 +26,7 @@ HIGHLY RECOMMENDED: Verify pod identity is operational on each AKS cluster.
 1. Obtain Subscription ID, AKS Resource Group name, AKS name, and Client ID of each pod identity:
 ```bash
 az account show --query "{subscriptionId: id}" -o table
-az aks list --query '[].{resourceGroup:resourceGroup, AksName:name, clientId: podIdentityProfile.userAssignedIdentities[0].identity.clientId}' -o table
+
 ````
 
 2. Merge the access credentials for each AKS cluster into your local kubeconfig by using the `aksCredentialCommands` outputs from Step 1:

--- a/docs/2.podidentity.md
+++ b/docs/2.podidentity.md
@@ -26,7 +26,7 @@ HIGHLY RECOMMENDED: Verify pod identity is operational on each AKS cluster.
 1. Obtain Subscription ID, AKS Resource Group name, AKS name, and Client ID of each pod identity:
 ```bash
 az account show --query "{subscriptionId: id}" -o table
-
+az aks list --query "[].{resourceGroup:resourceGroup, AksName:name, clientId: podIdentityProfile.userAssignedIdentities[0].identity.clientId}" -o table
 ````
 
 2. Merge the access credentials for each AKS cluster into your local kubeconfig by using the `aksCredentialCommands` outputs from Step 1:


### PR DESCRIPTION
…ry "[].

az aks list --query "[].{resourceGroup:resourceGroup, AksName:name, clientId: podIdentityProfile.userAssignedIdentities[0].identity.clientId}" -o table